### PR TITLE
change apt to package for CentOS/RHEL installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: KAFKA | Installing dependencies
-  apt:
-    pkg: "{{ kafka_required_libs }}"
+  package:
+    name: "{{ kafka_required_libs }}"
     state: present
   tags:
     skip_ansible_lint


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

I need use your role for some CentOS/RHEL hosts. Only one tasks in role use Debian-specified modules (apt in main.yaml). I changed it to use module https://docs.ansible.com/ansible/latest/modules/package_module.html

### Benefits

Support new OS

### Possible Drawbacks

nothing

### Applicable Issues

nothing