### PR TITLE
Minor updates tasks, and new extra tasks and plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,16 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Changed
 
+- Bump default Kafka version to 4.2.0
 - Remove `controller.quorum.voters` from default KRaft configuration (replaced by `controller.quorum.bootstrap.servers`)
-- Update molecule default scenario to Kafka 4.1.0 and remove `kafka_controller_quorum_voters` from group_vars
+- Update molecule default scenario to Kafka 4.2.0 and remove `kafka_controller_quorum_voters` from group_vars
 - Add `DOCKER_CLIENTS` listener to molecule default scenario for external client access
 - Fix comment typo in `defaults/main/kafka-cfg.yml` (`roker_cfg_default` → `broker_cfg_default`)
 - Update README wording for `controller.quorum.voters` example
+
+## Breaking Changes
+
+- `controller.quorum.voters` is no longer set by default. Users relying on it must add it explicitly via `broker_cfg_extra`
 
 ## [3.1.0](https://github.com/idealista/kafka_role/tree/3.1.0) (2026-01-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/kafka_role/tree/develop)
 
+## [3.2.0](https://github.com/idealista/kafka_role/tree/3.2.0) (2026-04-06)
+
+## Added
+
+- Add `kafka_plugins_tasks` support to allow running custom plugin installation tasks
+- Add `kafka_extra_tasks` support to allow running arbitrary extra tasks after role execution
+
+## Changed
+
+- Remove `controller.quorum.voters` from default KRaft configuration (replaced by `controller.quorum.bootstrap.servers`)
+- Update molecule default scenario to Kafka 4.1.0 and remove `kafka_controller_quorum_voters` from group_vars
+- Add `DOCKER_CLIENTS` listener to molecule default scenario for external client access
+- Fix comment typo in `defaults/main/kafka-cfg.yml` (`roker_cfg_default` → `broker_cfg_default`)
+- Update README wording for `controller.quorum.voters` example
+
 ## [3.1.0](https://github.com/idealista/kafka_role/tree/3.1.0) (2026-01-30)
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ kafka_process_roles: "broker,controller"  # broker, controller, or both
 kafka_cluster_uuid: "{{ 'kafka_role' | to_uuid | uuid_to_base64 }}"
 
 # List of all the controllers in the cluster with their node id and host/ip
-# An example to generate the controller quorum voters value could be:
+# An example (if needed) to generate the controller quorum voters value could be:
 kafka_controller_quorum_voters: "{{  groups['brokers'] | map('extract', hostvars, 'kafka_controller_uri') | join(',') }}"
 
 # List of all the listeners for the cluster

--- a/defaults/main/kafka-cfg.yml
+++ b/defaults/main/kafka-cfg.yml
@@ -8,7 +8,6 @@ kafka_cfg_default:
     properties:
       process.roles: "{{ kafka_process_roles | default('broker,controller') }}"
       node.id: "{{ kafka_node_id }}"
-      controller.quorum.voters: "{{ kafka_controller_quorum_voters }}"
       listeners: "{{ kafka_listeners }}"
       inter.broker.listener.name: "{{ kafka_inter_broker_listener_name }}"
       advertised.listeners: "{{ kafka_advertised_listeners }}"
@@ -21,7 +20,7 @@ kafka_cfg_default:
 
 # Brokers
 broker_cfg: "{{ [broker_cfg_default, broker_cfg_base | default([]), broker_cfg_extra | default([])] | community.general.lists_mergeby('section', recursive=true) }}"
-# roker_cfg_default: []
+# broker_cfg_default: []
 # broker_cfg_base: []
 # broker_cfg_extra: []
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -1,7 +1,7 @@
 ---
 ## General
 
-kafka_version: 4.1.0
+kafka_version: 4.2.0
 kafka_scala_version: 2.13  # Recommended
 kafka_use_kraft: true  # Use KRaft mode (Kafka Raft Metadata mode) instead of Zookeeper
 

--- a/molecule/default/group_vars/kafka.yml
+++ b/molecule/default/group_vars/kafka.yml
@@ -1,13 +1,12 @@
 ---
 
-kafka_version: 4.0.0
+kafka_version: 4.1.0
 
 kafka_private_tmp: false
 
 kafka_jvm_performance_opts: "-XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
 
 kafka_controller_quorum_bootstrap_servers: kafka1:9093,kafka2:9093,kafka3:9093
-kafka_controller_quorum_voters: "1@kafka1:9093,2@kafka2:9093,3@kafka3:9093"
 
 kafka_brokers_port: 9091
 kafka_clients_port: 9092
@@ -39,6 +38,10 @@ kafka_listeners_list:
   - name: CLIENTS
     host: "0.0.0.0:{{ kafka_clients_port }}"
     advertised_host: "{{ kafka_host_name }}:{{ kafka_clients_port }}"
+    protocol: PLAINTEXT
+  - name: DOCKER_CLIENTS
+    host: ":{{ kafka_advertised_ports[inventory_hostname]['clients_advertised_port'] }}"
+    advertised_host: "{{ kafka_host_name }}:{{ kafka_advertised_ports[inventory_hostname]['clients_advertised_port'] }}"
     protocol: PLAINTEXT
   - name: CONTROLLER
     host: "0.0.0.0:{{ kafka_controller_port }}"

--- a/molecule/default/group_vars/kafka.yml
+++ b/molecule/default/group_vars/kafka.yml
@@ -1,6 +1,6 @@
 ---
 
-kafka_version: 4.1.0
+kafka_version: 4.2.0
 
 kafka_private_tmp: false
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -112,6 +112,8 @@ provisioner:
       show_custom_stats: true
       fact_caching: yaml
       # fact_caching_connection: ./tmp/facts_cache
+    connection:
+      pipelining: True
 
 scenario:
   name: default

--- a/molecule/default/tests/3.0/test_kafka_topics.yml
+++ b/molecule/default/tests/3.0/test_kafka_topics.yml
@@ -1,13 +1,13 @@
 ---
 
 command:
-  {{ kafka_install_path }}/bin/kafka-topics.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --list:
+  "{{ kafka_install_path }}/bin/kafka-topics.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --list":
     exit-status: 0
     stdout:
     - "test"
     - "test2"
 
-  {{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name test --describe:
+  "{{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name test --describe":
     exit-status: 0
     stdout:
     - "Dynamic configs for topic test are:"
@@ -15,7 +15,7 @@ command:
     - "max.message.bytes=1024 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:max.message.bytes=1024, DEFAULT_CONFIG:message.max.bytes=1048588}"
     timeout: 20000
 
-  {{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name test2 --describe:
+  "{{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name test2 --describe":
     exit-status: 0
     stdout:
     - "Dynamic configs for topic test2 are:"
@@ -23,7 +23,7 @@ command:
     - "max.message.bytes=2048 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:max.message.bytes=2048, DEFAULT_CONFIG:message.max.bytes=1048588}"
     timeout: 20000
 
-  {{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name compacted-topic --describe:
+  "{{ kafka_install_path }}/bin/kafka-configs.sh --bootstrap-server {{ ansible_default_ipv4.address }}:{{ kafka_port }} --entity-type topics --entity-name compacted-topic --describe":
     exit-status: 0
     stdout:
     - "Dynamic configs for topic compacted-topic are:"

--- a/molecule/default/tests/test_kafka_service.yml
+++ b/molecule/default/tests/test_kafka_service.yml
@@ -6,19 +6,11 @@ service:
     running: true
 
 file:
-  {{ kafka_service_file_path }}:
+  "{{ kafka_service_file_path }}":
     exists: true
 
-# port:
-#   # https://github.com/goss-org/goss/blob/master/docs/gossfile.md#port
-#   # https://github.com/goss-org/goss/issues/149
-#   tcp6:{{ kafka_port }}:
-#     listening: true
-#     ip:
-#       - {{ ansible_default_ipv4.address }}
-# Alternative to check port because tcp and tcp6 inconsistencies
-command:
-  ss -tl | grep {{ kafka_port  }}:
-    exit-status: 0
-    stdout:
-      match-regexp: '^LISTEN(.*)(\:{{ kafka_port  }})(.*)'
+port:
+  tcp6:9092:
+    listening: true
+    ip:
+      - "::"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,10 +14,10 @@
   become: true
   gather_facts: true
   vars:
-    goss_version: v0.4.9
+    goss_version: v0.4.4
     goss_arch: amd64
     goss_dst: /usr/local/bin/goss
-    goss_sha256sum: 87dd36cfa1b8b50554e6e2ca29168272e26755b19ba5438341f7c66b36decc19
+    goss_sha256sum: 1c4f54b22fde9d4d5687939abc2606b0660a5d14a98afcd09b04b793d69acdc5
     goss_url: "https://github.com/goss-org/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
     goss_test_directory: /tmp
     goss_format: documentation

--- a/tasks/3.0/topic_config.yml
+++ b/tasks/3.0/topic_config.yml
@@ -55,7 +55,6 @@
     --entity-name {{ item.name }}
     --add-config {{ string_properties }}
     --alter
-    --force
     --bootstrap-server 0.0.0.0:{{ kafka_port }}
   when: kafka_topics_config_to_alter | trim  != string_properties
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,15 @@
     - kafka_agents_config
   when: kafka_agents_config is defined
 
+- name: KAFKA | Install plugins
+  ansible.builtin.include_tasks:
+    file: "{{ item }}"
+    apply:
+      tags: "{{ ['kafka_plugins_tasks'] + (kafka_plugins_tasks_tags | default([])) }}"
+  loop: "{{ kafka_plugins_tasks }}"
+  tags: "{{ ['kafka_plugins_tasks'] + (kafka_plugins_tasks_tags | default([])) }}"
+  when: kafka_plugins_tasks is defined
+
 - name: KAFKA | Configure
   ansible.builtin.import_tasks: config.yml
   tags:
@@ -41,3 +50,12 @@
     - kafka_acls
   when: kafka_acls is defined
   run_once: true
+
+- name: KAFKA | Extra tasks
+  ansible.builtin.include_tasks:
+    file: "{{ item }}"
+    apply:
+      tags: "{{ ['kafka_extra_tasks'] + (kafka_extra_tasks_tags | default([])) }}"
+  loop: "{{ kafka_extra_tasks }}"
+  tags: "{{ ['kafka_extra_tasks'] + (kafka_extra_tasks_tags | default([])) }}"
+  when: kafka_extra_tasks is defined


### PR DESCRIPTION
### Description of the Change

This PR introduces two new extensibility hooks into the role's task execution flow, bumps the default Kafka version to 4.2.0, and aligns the default KRaft configuration with Kafka 4.x conventions.

**Extensibility hooks (`tasks/main.yml`)**

Two new optional variables allow users to inject custom Ansible task files into the role without forking it:

- `kafka_plugins_tasks`: a list of task file paths executed after agent configuration, intended for installing Kafka plugins (e.g. connector JARs, custom libraries).
- `kafka_extra_tasks`: a list of task file paths executed at the very end of the role, after ACL setup, for any post-configuration custom logic.

Both use `include_tasks` in a loop. Tags are forwarded via `kafka_plugins_tasks_tags` / `kafka_extra_tasks_tags` so callers can still scope execution with `--tags`. When the variables are not defined the tasks are skipped entirely — no impact on existing deployments.

**Remove `controller.quorum.voters` from default KRaft config (`defaults/main/kafka-cfg.yml`)**

In Kafka 4.x KRaft mode, `controller.quorum.voters` is superseded by `controller.quorum.bootstrap.servers`. Keeping it in `kafka_cfg_default` caused failures for clusters that don't define `kafka_controller_quorum_voters`. It has been removed from the default config; users who still need it can add it back via `broker_cfg_extra`.

**Molecule default scenario (`molecule/default/group_vars/kafka.yml`)**

- Bumped `kafka_version` to `4.2.0`.
- Removed `kafka_controller_quorum_voters` from group_vars, consistent with the config change above.
- Added a `DOCKER_CLIENTS` listener with a dedicated advertised port to allow external clients to connect from outside the container network during molecule tests.

**Minor fixes**

- Fixed typo in `defaults/main/kafka-cfg.yml`: `# roker_cfg_default` → `# broker_cfg_default`.
- Clarified README wording for the `controller.quorum.voters` example (marked as optional).

### Benefits

- Users can extend the role with custom plugins or post-configuration tasks without forking it, reducing maintenance overhead for consumers of the role.
- Removes a broken default (`controller.quorum.voters`) that caused KRaft cluster provisioning to fail when `kafka_controller_quorum_voters` was not explicitly set.
- Keeps the role aligned with the latest stable Kafka release (4.2.0).
- Molecule tests now reflect the current recommended KRaft setup and support external client connectivity scenarios.

### Possible Drawbacks

- `controller.quorum.voters` is no longer set by default. Users relying on it being injected automatically must add it explicitly via `broker_cfg_extra`.

### Applicable Issues

N/A